### PR TITLE
Fix admin user listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ After registration, the user is redirected back to the login page.
 
 Sample Firestore security rules are included in `firestore.rules`.
 
+The **Delete** button on the general panel currently just shows a toast message.
+Actual account removal isn't implemented yet.
+
 The Firebase configuration in `auth.js` points to a sample project. Replace the
 credentials with your own Firebase project settings if you deploy this
 application.

--- a/auth.js
+++ b/auth.js
@@ -147,9 +147,13 @@ if (location.pathname.includes("admin.html")) {
     if (holdConf.exists()) $("relayHoldTime").value = holdConf.data().ms || 3000;
 
     const snapUsers = await getDocs(collection(db, "users"));
+    const list = $("userList");
+    list.innerHTML = "";
+    let found = false;
     snapUsers.forEach(docSnap => {
       const u = docSnap.data();
       if (u.role === "admin") return;
+      found = true;
       const row = document.createElement("div");
       row.className = "p-2 bg-gray-700 rounded flex justify-between items-center";
       row.innerHTML = `
@@ -167,8 +171,11 @@ if (location.pathname.includes("admin.html")) {
         label.textContent = `${u.name} → ${sel.value}`;
         showNotif("Role updated");
       };
-      $("userList").appendChild(row);
+      list.appendChild(row);
     });
+    if (!found) {
+      list.innerHTML = "<p class='text-center text-gray-400'>No users found</p>";
+    }
   });
 
   window.saveTimeout = async () => {
@@ -198,4 +205,9 @@ if (location.pathname.includes("admin.html")) {
 window.logout = async () => {
   await signOut(auth);
   location.href = "index.html";
+};
+
+// Placeholder account deletion
+window.deleteAccount = () => {
+  showNotif("Account deletion coming soon");
 };

--- a/general.html
+++ b/general.html
@@ -7,10 +7,10 @@
   <style>#toast{transition:opacity .3s;} .hidden{opacity:0;}</style>
 </head>
 <body class="bg-gray-900 text-white min-h-screen p-6 flex flex-col items-center justify-center">
-  <button id="toggleBtn" class="w-[90vw] h-[90vh] text-4xl font-bold rounded bg-red-600">LOCKED</button>
+  <button id="toggleBtn" class="w-[90vw] h-[90vh] text-4xl font-bold rounded bg-red-600 cursor-pointer">LOCKED</button>
   <div class="mt-6 flex gap-4">
     <button onclick="logout()" class="bg-gray-700 px-4 py-2 rounded">Logout</button>
-    <button onclick="showNotif('Account deletion coming soon')" class="bg-gray-700 px-4 py-2 rounded">Delete</button>
+    <button onclick="deleteAccount()" class="bg-gray-700 px-4 py-2 rounded">Delete</button>
     <button id="copyBtn" class="hidden bg-gray-700 px-4 py-2 rounded">Copy Token</button>
   </div>
 


### PR DESCRIPTION
## Summary
- clean and repopulate the user list in admin panel
- show a placeholder message if there are no users
- add cursor pointer to the general panel toggle button
- document that account deletion is only a placeholder

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684d007a38f48329b5c23ab68ab53a2b