### PR TITLE
Make delete button a placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ The Firebase configuration in `auth.js` points to a sample project. Replace the
 credentials with your own Firebase project settings if you deploy this
 application.
 
-Account deletion is supported from the general panel. The action calls a Cloud
-Function that removes the signed-in user from Firebase Auth and signs them out.
+The general panel includes a **Delete** button. It currently serves as a
+placeholder and only shows a notification. The underlying `deleteAccount` Cloud
+Function is still provided in `functions/index.js` should you wish to wire it up
+for actual account removal.
 
 Firebase Hosting configuration files are included along with a GitHub Actions
 workflow that deploys preview channels for pull requests and pushes to the live

--- a/auth.js
+++ b/auth.js
@@ -202,14 +202,8 @@ window.logout = async () => {
   location.href = "index.html";
 };
 
-window.deleteAccount = async () => {
-  try {
-    const callDelete = httpsCallable(functions, "deleteAccount");
-    await callDelete();
-    showNotif("Account deleted");
-    await signOut(auth);
-    location.href = "index.html";
-  } catch (err) {
-    showNotif("Failed to delete account");
-  }
+// Placeholder delete action - the Cloud Function remains but
+// the UI now only shows a notification.
+window.deleteAccount = () => {
+  showNotif("Account deletion not implemented yet");
 };


### PR DESCRIPTION
## Summary
- disable account deletion by turning the Delete button into a placeholder
- note the placeholder Delete button in the README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684d04a6a4348329bb566aed0cf10624