### PR TITLE
Improve cross-browser toggle and mobile responsiveness

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ placeholder and only shows a notification. The underlying `deleteAccount` Cloud
 Function is still provided in `functions/index.js` should you wish to wire it up
 for actual account removal.
 
+The large toggle on the general panel now updates the `config/relaystate`
+document in Firestore. When pressed it sets the state to `unlocked` and reverts
+to `locked` after the admin-defined relay hold time. The interface uses standard
+event listeners for better browser compatibility and pages now include viewport
+metadata and responsive layout tweaks for improved usability on mobile devices.
+
 Firebase Hosting configuration files are included along with a GitHub Actions
 workflow that deploys preview channels for pull requests and pushes to the live
 site on merges to `main`.

--- a/admin.html
+++ b/admin.html
@@ -2,11 +2,12 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>DaBox Admin Panel</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <style>#toast { transition: opacity 0.3s; } .hidden { opacity: 0; }</style>
 </head>
-<body class="bg-gray-900 text-white min-h-screen p-6 flex items-center justify-center">
+<body class="bg-gray-900 text-white min-h-screen p-4 sm:p-6 flex items-center justify-center">
   <div class="w-full max-w-xl space-y-6">
     <header class="flex justify-between items-center">
       <h1 class="text-3xl font-semibold">Admin Panel</h1>

--- a/auth.js
+++ b/auth.js
@@ -112,21 +112,32 @@ if (location.href.includes("general")) {
         const hold = await getDoc(doc(db, "config", "relayHoldTime"));
         if (hold.exists()) holdMs = hold.data().ms || holdMs;
 
-        toggleBtn.onclick = () => {
+        const stateDoc = doc(db, "config", "relaystate");
+        toggleBtn.addEventListener("click", async () => {
           if (unlocked) return;
           unlocked = true;
           toggleBtn.textContent = "UNLOCKED";
           toggleBtn.classList.remove("bg-red-600");
           toggleBtn.classList.add("bg-green-600");
           toggleBtn.disabled = true;
-          setTimeout(() => {
+          try {
+            await setDoc(stateDoc, { state: "unlocked" });
+          } catch {
+            showNotif("Failed to update relay state");
+          }
+          setTimeout(async () => {
             unlocked = false;
             toggleBtn.textContent = "LOCKED";
             toggleBtn.classList.remove("bg-green-600");
             toggleBtn.classList.add("bg-red-600");
             toggleBtn.disabled = false;
+            try {
+              await setDoc(stateDoc, { state: "locked" });
+            } catch {
+              showNotif("Failed to update relay state");
+            }
           }, holdMs);
-        };
+        });
 
         if (role === "sub") {
           copyBtn.classList.remove("hidden");

--- a/general.html
+++ b/general.html
@@ -2,12 +2,13 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>DaBox General Panel</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <style>#toast{transition:opacity .3s;} .hidden{opacity:0;}</style>
 </head>
-<body class="bg-gray-900 text-white min-h-screen p-6 flex flex-col items-center justify-center">
-  <button id="toggleBtn" class="w-[90vw] h-[90vh] text-4xl font-bold rounded bg-red-600">LOCKED</button>
+<body class="bg-gray-900 text-white min-h-screen p-4 sm:p-6 flex flex-col items-center justify-center">
+  <button id="toggleBtn" class="w-64 h-64 sm:w-72 sm:h-72 md:w-80 md:h-80 text-3xl sm:text-4xl font-bold rounded bg-red-600">LOCKED</button>
     <div class="mt-6 flex gap-4">
       <button onclick="logout()" class="bg-gray-700 px-4 py-2 rounded">Logout</button>
       <button onclick="deleteAccount()" class="bg-gray-700 px-4 py-2 rounded">Delete</button>

--- a/index.html
+++ b/index.html
@@ -2,13 +2,14 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>DaBox Login</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="icon" href="favicon.ico" />
   <style>#toast{transition:opacity .3s;} .hidden{opacity:0;}</style>
 </head>
-<body class="bg-gray-900 text-white min-h-screen flex items-center justify-center p-6">
-  <div id="authContainer" class="w-full max-w-sm bg-gray-800 p-6 rounded shadow space-y-4">
+<body class="bg-gray-900 text-white min-h-screen flex items-center justify-center p-4 sm:p-6">
+  <div id="authContainer" class="w-full max-w-xs sm:max-w-sm md:max-w-md bg-gray-800 p-4 sm:p-6 rounded shadow mx-auto space-y-4">
     <h2 class="text-xl font-bold text-center">Welcome to DaBox</h2>
     <input id="email" type="email" placeholder="Email" class="w-full p-2 bg-gray-700 rounded border border-gray-600" />
     <input id="password" type="password" placeholder="Password" class="w-full p-2 bg-gray-700 rounded border border-gray-600" />

--- a/register.html
+++ b/register.html
@@ -2,12 +2,13 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>DaBox Register</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <style>#toast{transition:opacity .3s;} .hidden{opacity:0;}</style>
 </head>
-<body class="bg-gray-900 text-white min-h-screen flex items-center justify-center p-6">
-  <div id="regContainer" class="w-full max-w-sm bg-gray-800 p-6 rounded shadow space-y-4">
+<body class="bg-gray-900 text-white min-h-screen flex items-center justify-center p-4 sm:p-6">
+  <div id="regContainer" class="w-full max-w-xs sm:max-w-sm md:max-w-md bg-gray-800 p-4 sm:p-6 rounded shadow mx-auto space-y-4">
     <h2 class="text-xl font-bold text-center">Create Account</h2>
     <input id="name" type="text" placeholder="Name" class="w-full p-2 bg-gray-700 rounded border border-gray-600" />
     <input id="regEmail" type="email" placeholder="Email" class="w-full p-2 bg-gray-700 rounded border border-gray-600" />


### PR DESCRIPTION
## Summary
- make all pages responsive with viewport meta tags
- tweak login and register layouts for small screens
- adjust general toggle styles
- update toggle logic to write relay state to Firestore
- document new behaviour in README

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684e2c5dbf4c8329b1af7e3f21ea6406