### PR TITLE
Add error reporting and offline code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Toggle Demo
 
-This project is a small example showing how to use Firebase for authentication and data sync. It features a large toggle button whose state is stored in Firestore and mirrored to the Realtime Database at `https://da-box-59.firebaseio.com`.
+This is a lightweight example showing how Firebase authentication and a realtime toggle could work together. The toggle state is stored in Firestore and mirrored to your project's Realtime Database.
 
 ## Setup
 
@@ -17,9 +17,8 @@ This project is a small example showing how to use Firebase for authentication a
 ## Usage
 
 - **Login** on the landing page.
-- The **General** panel contains a big toggle that switches between locked and unlocked states. The value is written to Firestore and to the Realtime Database so other clients can react immediately.
-- Use **Offline Code** to copy a placeholder token for future offline access.
-- **Report Issue** opens a form to send feedback. Reports are stored under the `errors` collection for admins to view.
-- Admins can generate invite links, adjust timeouts and review error reports in `admin.html`.
+- On the **General** panel, the large toggle flips between locked and unlocked. The value is written to Firestore and the Realtime Database so other clients update instantly.
+- **Offline Code** copies a placeholder token to the clipboard for later use.
+- **Report Issue** opens a form to send feedback. Reports are saved for admins to review.
 
 Replace the Firebase configuration in `auth.js` with your own project details if you deploy this demo.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# DaBox 59
+# Toggle Demo
 
-A minimal Firebase-based authentication demo with admin and general panels.
+This project is a small example showing how to use Firebase for authentication and data sync. It features a large toggle button whose state is stored in Firestore and mirrored to the Realtime Database at `https://da-box-59.firebaseio.com`.
 
 ## Setup
 
@@ -8,54 +8,18 @@ A minimal Firebase-based authentication demo with admin and general panels.
    ```bash
    npm install
    ```
-
-2. Start a development server
+2. Start the static server
    ```bash
    npm start
    ```
-   This uses `http-server` to serve the static files on `http://localhost:8080`.
+   Then open `index.html` in your browser.
 
-3. Open `index.html` in your browser to log in.
+## Usage
 
-## Project Structure
+- **Login** on the landing page.
+- The **General** panel contains a big toggle that switches between locked and unlocked states. The value is written to Firestore and to the Realtime Database so other clients can react immediately.
+- Use **Offline Code** to copy a placeholder token for future offline access.
+- **Report Issue** opens a form to send feedback. Reports are stored under the `errors` collection for admins to view.
+- Admins can generate invite links, adjust timeouts and review error reports in `admin.html`.
 
-- `index.html` – login page
-- `admin.html` – admin panel
-- `general.html` – general user panel
-- `register.html` – registration page used with invite tokens
-- `auth.js` – shared Firebase logic and toast notifications (exposed as `showNotif`)
-
-The admin panel lets you adjust the inactivity timeout and the relay hold time.
-It also lists all non-admin users with a dropdown to change their roles. Role
-changes are saved immediately when you pick a new value and a toast confirms the
-update. Configuration documents are readable by any signed-in user so the
-general panel can display the relay hold time. Admins are allowed to update any
-user document so role changes persist.
-
-Invite tokens can be generated from the admin panel. Opening a token link will
-take the user to `register.html` where they can sign up. The login page no
-longer links to registration directly, so invitees must use their token URL.
-After registration, the user is redirected back to the login page.
-
-Sample Firestore security rules are included in `firestore.rules`.
-
-The Firebase configuration in `auth.js` points to a sample project. Replace the
-credentials with your own Firebase project settings if you deploy this
-application.
-
-The general panel includes a **Delete** button. It currently serves as a
-placeholder and only shows a notification. The underlying `deleteAccount` Cloud
-Function is still provided in `functions/index.js` should you wish to wire it up
-for actual account removal.
-
-The large toggle on the general panel now updates the `config/relaystate`
-document in Firestore. When pressed it sets the state to `unlocked` and reverts
-to `locked` after the admin-defined relay hold time. Authenticated users can now
-update this document as specified in `firestore.rules`. The interface uses
-standard event listeners for better browser compatibility and pages now include
-viewport metadata and responsive layout tweaks for improved usability on mobile
-devices.
-
-Firebase Hosting configuration files are included along with a GitHub Actions
-workflow that deploys preview channels for pull requests and pushes to the live
-site on merges to `main`.
+Replace the Firebase configuration in `auth.js` with your own project details if you deploy this demo.

--- a/admin.html
+++ b/admin.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>DaBox Admin Panel</title>
   <script src="https://cdn.tailwindcss.com"></script>
-  <style>#toast { transition: opacity 0.3s; } .hidden { opacity: 0; }</style>
+  <style>#toast { transition: opacity 0.3s; } .hidden { opacity: 0; } body{font-family:system-ui,sans-serif; }</style>
 </head>
 <body class="bg-gray-900 text-white min-h-screen p-4 sm:p-6 flex items-center justify-center">
   <div class="w-full max-w-xl space-y-6">
@@ -30,6 +30,8 @@
     </div>
 
     <div id="userList" class="space-y-2"></div>
+    <h2 class="text-xl mt-6">Error Reports</h2>
+    <div id="errorList" class="space-y-2"></div>
   </div>
 
   <div id="toast" class="fixed bottom-4 right-4 bg-gray-800 text-white px-4 py-2 rounded hidden"></div>
@@ -130,6 +132,16 @@
           showNotif(`Role updated to ${sel.value}`);
         };
         $("userList").appendChild(row);
+      });
+
+      const snapErr = await getDocs(collection(db, "errors"));
+      snapErr.forEach(errSnap => {
+        const e = errSnap.data();
+        const item = document.createElement("div");
+        item.className = "p-2 bg-gray-700 rounded";
+        const ts = e.createdAt?.toDate().toLocaleString() || "";
+        item.textContent = `${ts} - ${e.message}`;
+        $("errorList").appendChild(item);
       });
     });
   </script>

--- a/auth.js
+++ b/auth.js
@@ -5,9 +5,10 @@ import {
 } from "https://www.gstatic.com/firebasejs/10.12.0/firebase-auth.js";
 import {
   getFirestore, doc, setDoc, getDoc, updateDoc,
-  collection, getDocs, serverTimestamp
+  collection, getDocs, serverTimestamp, addDoc
 } from "https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js";
 import { getFunctions } from "https://www.gstatic.com/firebasejs/10.12.0/firebase-functions.js";
+import { getDatabase, ref, set } from "https://www.gstatic.com/firebasejs/10.12.0/firebase-database.js";
 import { v4 as uuidv4 } from "https://jspm.dev/uuid";
 
 const firebaseConfig = {
@@ -16,13 +17,15 @@ const firebaseConfig = {
   projectId: "da-box-59",
   storageBucket: "da-box-59.firebasestorage.app",
   messagingSenderId: "382682873063",
-  appId: "1:382682873063:web:e240e1bf8e14527b277642"
+  appId: "1:382682873063:web:e240e1bf8e14527b277642",
+  databaseURL: "https://da-box-59.firebaseio.com"
 };
 
 const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
 const db = getFirestore(app);
 const functions = getFunctions(app);
+const rtdb = getDatabase(app);
 const $ = (id) => document.getElementById(id);
 const showNotif = (msg) => {
   const el = $("toast");
@@ -100,6 +103,12 @@ if (location.href.includes("general")) {
   window.addEventListener("DOMContentLoaded", () => {
     const toggleBtn = $("toggleBtn");
     const copyBtn = $("copyBtn");
+    const offlineBtn = $("offlineBtn");
+    const errorBtn = $("errorBtn");
+    const modal = $("errorModal");
+    const errorText = $("errorText");
+    const cancelError = $("cancelError");
+    const sendError = $("sendError");
     let unlocked = false;
     let holdMs = 3000;
 
@@ -113,6 +122,19 @@ if (location.href.includes("general")) {
         if (hold.exists()) holdMs = hold.data().ms || holdMs;
 
         const stateDoc = doc(db, "config", "relaystate");
+
+        const updateRelay = async (val) => {
+          try {
+            await Promise.all([
+              setDoc(stateDoc, { state: val }),
+              set(ref(rtdb, "relaystate"), val)
+            ]);
+            return true;
+          } catch {
+            return false;
+          }
+        };
+
         toggleBtn.addEventListener("click", async () => {
           if (unlocked) return;
           unlocked = true;
@@ -120,9 +142,8 @@ if (location.href.includes("general")) {
           toggleBtn.classList.remove("bg-red-600");
           toggleBtn.classList.add("bg-green-600");
           toggleBtn.disabled = true;
-          try {
-            await setDoc(stateDoc, { state: "unlocked" });
-          } catch {
+          const ok1 = await updateRelay("unlocked");
+          if (!ok1) {
             showNotif("Failed to update relay state");
           }
           setTimeout(async () => {
@@ -131,9 +152,8 @@ if (location.href.includes("general")) {
             toggleBtn.classList.remove("bg-green-600");
             toggleBtn.classList.add("bg-red-600");
             toggleBtn.disabled = false;
-            try {
-              await setDoc(stateDoc, { state: "locked" });
-            } catch {
+            const ok2 = await updateRelay("locked");
+            if (!ok2) {
               showNotif("Failed to update relay state");
             }
           }, holdMs);
@@ -152,6 +172,29 @@ if (location.href.includes("general")) {
             showNotif("Token copied:\n" + url);
           };
         }
+
+        offlineBtn.onclick = async () => {
+          const code = uuidv4();
+          await navigator.clipboard.writeText(code);
+          showNotif("Offline code copied:\n" + code);
+        };
+
+        errorBtn.onclick = () => {
+          modal.classList.remove("hidden");
+          errorText.value = "";
+        };
+        cancelError.onclick = () => modal.classList.add("hidden");
+        sendError.onclick = async () => {
+          const msg = errorText.value.trim();
+          if (!msg) return;
+          await addDoc(collection(db, "errors"), {
+            message: msg,
+            user: user.uid,
+            createdAt: serverTimestamp()
+          });
+          modal.classList.add("hidden");
+          showNotif("Issue reported");
+        };
       }
     });
   });

--- a/general.html
+++ b/general.html
@@ -5,17 +5,29 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>DaBox General Panel</title>
   <script src="https://cdn.tailwindcss.com"></script>
-  <style>#toast{transition:opacity .3s;} .hidden{opacity:0;}</style>
+  <style>#toast{transition:opacity .3s;} .hidden{opacity:0;} body{font-family:system-ui,sans-serif;}</style>
 </head>
 <body class="bg-gray-900 text-white min-h-screen p-4 sm:p-6 flex flex-col items-center justify-center">
   <button id="toggleBtn" class="w-[90vw] h-[90vh] max-w-xs sm:max-w-none rounded-xl shadow-lg text-4xl font-bold bg-red-600">LOCKED</button>
-    <div class="mt-6 flex gap-4">
-      <button onclick="logout()" class="bg-gray-700 px-4 py-2 rounded">Logout</button>
-      <button onclick="deleteAccount()" class="bg-gray-700 px-4 py-2 rounded">Delete</button>
-      <button id="copyBtn" class="hidden bg-gray-700 px-4 py-2 rounded">Copy Token</button>
-    </div>
+  <div class="mt-6 flex flex-wrap gap-4 justify-center">
+    <button onclick="logout()" class="bg-gray-700 px-4 py-2 rounded">Logout</button>
+    <button onclick="deleteAccount()" class="bg-gray-700 px-4 py-2 rounded">Delete</button>
+    <button id="copyBtn" class="hidden bg-gray-700 px-4 py-2 rounded">Copy Token</button>
+    <button id="offlineBtn" class="bg-gray-700 px-4 py-2 rounded">Offline Code</button>
+    <button id="errorBtn" class="bg-gray-700 px-4 py-2 rounded">Report Issue</button>
+  </div>
 
   <div id="toast" class="fixed bottom-4 right-4 bg-gray-800 text-white px-4 py-2 rounded hidden"></div>
+
+  <div id="errorModal" class="fixed inset-0 bg-black/50 flex items-center justify-center hidden">
+    <div class="bg-gray-800 p-4 rounded space-y-4 w-full max-w-md">
+      <textarea id="errorText" rows="4" class="w-full p-2 bg-gray-700 rounded" placeholder="Describe the issue..."></textarea>
+      <div class="flex justify-end gap-2">
+        <button id="cancelError" class="bg-gray-600 px-4 py-2 rounded">Cancel</button>
+        <button id="sendError" class="bg-blue-600 px-4 py-2 rounded">Send</button>
+      </div>
+    </div>
+  </div>
 
   <script type="module" src="auth.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>DaBox Login</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="icon" href="favicon.ico" />
-  <style>#toast{transition:opacity .3s;} .hidden{opacity:0;}</style>
+  <style>#toast{transition:opacity .3s;} .hidden{opacity:0;} body{font-family:system-ui,sans-serif;}</style>
 </head>
 <body class="bg-gray-900 text-white min-h-screen flex items-center justify-center p-4 sm:p-6">
   <div id="authContainer" class="w-full max-w-xs sm:max-w-sm md:max-w-md bg-gray-800 p-4 sm:p-6 rounded shadow mx-auto space-y-4">

--- a/register.html
+++ b/register.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>DaBox Register</title>
   <script src="https://cdn.tailwindcss.com"></script>
-  <style>#toast{transition:opacity .3s;} .hidden{opacity:0;}</style>
+  <style>#toast{transition:opacity .3s;} .hidden{opacity:0;} body{font-family:system-ui,sans-serif;}</style>
 </head>
 <body class="bg-gray-900 text-white min-h-screen flex items-center justify-center p-4 sm:p-6">
   <div id="regContainer" class="w-full max-w-xs sm:max-w-sm md:max-w-md bg-gray-800 p-4 sm:p-6 rounded shadow mx-auto space-y-4">


### PR DESCRIPTION
## Summary
- add simple error report feature with modal form
- provide offline code button copying a token to clipboard
- display reported errors in admin panel
- streamline fonts across pages
- create public README without private details

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684ebc99e7bc8329a0441870b3fb64df