### PR TITLE
Implement user intro and offline AP info

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@ This app provides a simple interface for unlocking and locking a relay using Fir
 - **Report Issue** opens a form so users can submit feedback. Reports show up for admins on their panel.
 - Admins can remove reports directly from the error list.
 - Sub users can generate invitation links via **Copy Token** on the general panel.
-- The `esp32_relay_watch.ino` sketch demonstrates how an ESP32 watches the database. It toggles pin **13** when `/relaystate` becomes `unlocked` and pin **12** when `/medRelaystate` is `unlocked`, then resets the relay after the configured hold time.
+- New users see a brief introduction modal the first time they sign in. It explains the controls and notes that account deletion is coming soon.
+  - The `esp32_relay_watch.ino` sketch demonstrates how an ESP32 watches the database. It toggles pin **13** when `/relaystate` becomes `unlocked` and pin **12** when `/medRelaystate` is `unlocked`, then resets the relay after the configured hold time.
 - If WiFi isn't available (or drops later), the sketch switches to a fallback access point `DaBox-AP` with a small web page at `http://192.168.4.1`. Use the displayed 4-digit PIN to unlock when offline. The pin is written to `/offlinePin` whenever WiFi reconnects.
 - If the configured WiFi can't be reached, the board scans for open networks and connects to the strongest one so it stays online.
 - Over-the-air updates are available via a simple `/update` endpoint so admins can upload new firmware directly from the web UI.
-- The general panel watches `/offlinePin` in the Realtime Database. When the board goes offline a modal shows the current PIN and explains how to reach the AP.
+- The general panel watches `/offlinePin` in the Realtime Database. When the board goes offline a modal shows the current PIN and displays the fallback AP credentials with copy buttons.
  - Relay hold time saved from the admin panel is also stored in the Realtime Database at `/relayHoldTime/ms`. Both toggles write the same value whenever they unlock so hardware sees the latest hold time. The ESP writes `locked` back when the cycle ends so the UI only reverts once the board confirms.
 - The general panel shows a green "Device online" message when a heartbeat is received from the ESP and turns red when the heartbeat stops.
 - Admins can grant a **med** role. Users with this role see a second toggle on the general panel which writes to `medRelaystate`.

--- a/admin.html
+++ b/admin.html
@@ -41,6 +41,13 @@
 
   <div id="toast" class="fixed bottom-4 right-4 bg-gray-800 text-white px-4 py-2 rounded hidden"></div>
 
+  <div id="introModal" class="fixed inset-0 bg-black/50 flex items-center justify-center hidden">
+    <div class="bg-gray-800 p-4 rounded space-y-4 w-full max-w-md text-center">
+      <p>Welcome to DaBox! Use this panel to adjust settings, manage users and review reports.</p>
+      <button id="closeIntro" class="bg-blue-600 px-4 py-2 rounded w-full">Got it</button>
+    </div>
+  </div>
+
   <script type="module">
     import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.0/firebase-app.js";
     import {
@@ -134,6 +141,18 @@
       if (!user) return location.href = "index.html";
       const snap = await getDoc(doc(db, "users", user.uid));
       if (snap.data()?.role !== "admin") return location.href = "general.html";
+
+      if (!snap.data()?.intro) {
+        const modal = document.getElementById("introModal");
+        const closeIntro = document.getElementById("closeIntro");
+        if (modal && closeIntro) {
+          modal.classList.remove("hidden");
+          closeIntro.onclick = async () => {
+            modal.classList.add("hidden");
+            await updateDoc(doc(db, "users", user.uid), { intro: true });
+          };
+        }
+      }
 
       const conf = await getDoc(doc(db, "config", "inactivity"));
       if (conf.exists()) $("inactivityTimeout").value = conf.data().timeout || 3000;

--- a/auth.js
+++ b/auth.js
@@ -88,7 +88,8 @@ if (location.href.includes("register")) {
         await setDoc(doc(db, "users", cred.user.uid), {
           name,
           role: "general",
-          roles: []
+          roles: [],
+          intro: false
         });
         await updateDoc(doc(db, "registerTokens", token), { used: true });
         showNotif("Registration successful");
@@ -113,7 +114,11 @@ if (location.href.includes("general")) {
     const offlineModal = $("offlineModal");
     const closeOffline = $("closeOffline");
     const launchOffline = $("launchOffline");
+    const copySsid = $("copySsid");
+    const copyPass = $("copyPass");
     const offlineCodeInput = $("offlineCodeInput");
+    const offlineSsid = "DaBox-AP";
+    const offlinePwd = "daboxpass";
     const errorText = $("errorText");
     const cancelError = $("cancelError");
     const sendError = $("sendError");
@@ -141,6 +146,18 @@ if (location.href.includes("general")) {
 
       applyMedToggle(rolesArr);
       onSnapshot(uRef, (s) => applyMedToggle(s.data()?.roles || []));
+
+      if (!uSnap.data()?.intro) {
+        const modal = $("introModal");
+        const close = $("closeIntro");
+        if (modal && close) {
+          modal.classList.remove("hidden");
+          close.onclick = async () => {
+            modal.classList.add("hidden");
+            await updateDoc(uRef, { intro: true });
+          };
+        }
+      }
 
       if (role !== "admin") {
         const hold = await getDoc(doc(db, "config", "relayHoldTime"));
@@ -256,6 +273,15 @@ if (location.href.includes("general")) {
           offlineCodeInput.value = offlinePin;
           showNotif("PIN copied:\n" + offlinePin);
           offlineModal.classList.remove("hidden");
+        };
+
+        if (copySsid) copySsid.onclick = () => {
+          navigator.clipboard.writeText(offlineSsid);
+          showNotif("SSID copied");
+        };
+        if (copyPass) copyPass.onclick = () => {
+          navigator.clipboard.writeText(offlinePwd);
+          showNotif("Password copied");
         };
 
         closeOffline.onclick = () => {

--- a/general.html
+++ b/general.html
@@ -35,10 +35,21 @@
 
   <div id="offlineModal" class="fixed inset-0 bg-black/50 flex items-center justify-center hidden">
     <div class="bg-gray-800 p-4 rounded space-y-4 w-full max-w-md text-center">
-      <p>Device appears offline. Connect to <b>DaBox-AP</b> and use the PIN below.</p>
+      <p>Device appears offline. Connect to <b>DaBox-AP</b> (password <b>daboxpass</b>) and use the PIN below.</p>
+      <div class="flex gap-2">
+        <button id="copySsid" class="bg-gray-700 px-2 py-1 rounded w-full">Copy SSID</button>
+        <button id="copyPass" class="bg-gray-700 px-2 py-1 rounded w-full">Copy Password</button>
+      </div>
       <input id="offlineCodeInput" class="w-full p-2 bg-gray-700 rounded" placeholder="Offline PIN" />
       <button id="launchOffline" class="bg-blue-600 px-4 py-2 rounded w-full">Open AP Link</button>
       <button id="closeOffline" class="bg-gray-600 px-2 py-1 rounded w-full">Close</button>
+    </div>
+  </div>
+
+  <div id="introModal" class="fixed inset-0 bg-black/50 flex items-center justify-center hidden">
+    <div class="bg-gray-800 p-4 rounded space-y-4 w-full max-w-md text-center">
+      <p>Welcome to DaBox! Tap the big button to lock or unlock. Use Logout when you're done. The Delete button isn't active yet.</p>
+      <button id="closeIntro" class="bg-blue-600 px-4 py-2 rounded w-full">Got it</button>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- introduce an intro modal on first login
- store intro flag in user doc
- show AP credentials and copy buttons in offline modal
- document new behaviour in README
- refine intro text for both admin and general panels

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_685422981a508329ac21a8a1cbd89131