### PR TITLE
Improve offline UX and admin controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ This app provides a simple interface for unlocking and locking a relay using Fir
 - Over-the-air updates are available via a simple `/update` endpoint so admins can upload new firmware directly from the web UI.
 - The general panel reads `/offlinePinGeneral` for normal users and `/offlinePinSub` for sub admins to display the current PIN when the device goes offline.
  - Relay hold time saved from the admin panel is also stored in the Realtime Database at `/relayHoldTime/ms`. Both toggles write the same value whenever they unlock so hardware sees the latest hold time. The ESP writes `locked` back when the cycle ends so the UI only reverts once the board confirms.
-- The general panel shows a green heart when the ESP heartbeat is active and it turns red when the heartbeat stops.
+ - The general panel shows a faint heart centered behind the toggles. It glows green when the ESP heartbeat updates and turns red when it stops.
 - Admins can lock user accounts from the admin panel so locked users cannot sign in.
 - Sub admins use a wizard to generate invitation links specifying the role and optional med access.
 - Admins can grant a **med** role. Users with this role see a second toggle on the general panel which writes to `medRelaystate`.
 - The ESP32 watches `medRelaystate` as well and unlocks the relay when this value becomes `unlocked`.
- - When offline, the general panel instructs users to join the `da-box-59` AP and provides a button to copy the PIN and local link. This link already includes the PIN so it opens directly to the unlock page. Sub admins can upload firmware from the ESP's local page.
+ - When offline, the general panel keeps its help modal open until dismissed. It guides users to join the `da-box-59` AP and offers a copy button for the PIN and local link, which already embeds the PIN. Sub admins can also upload firmware from the ESP's local page.
 Replace the Firebase configuration in `auth.js` with your own project details before deploying.

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ This app provides a simple interface for unlocking and locking a relay using Fir
 - Over-the-air updates are available via a simple `/update` endpoint so admins can upload new firmware directly from the web UI.
 - The general panel reads `/offlinePinGeneral` for normal users and `/offlinePinSub` for sub admins to display the current PIN when the device goes offline.
  - Relay hold time saved from the admin panel is also stored in the Realtime Database at `/relayHoldTime/ms`. Both toggles write the same value whenever they unlock so hardware sees the latest hold time. The ESP writes `locked` back when the cycle ends so the UI only reverts once the board confirms.
-- The general panel shows a pulsing green heart when the ESP heartbeat is active and turns red when it stops.
+- The general panel shows a green heart when the ESP heartbeat is active and it turns red when the heartbeat stops.
 - Admins can lock user accounts from the admin panel so locked users cannot sign in.
 - Sub admins use a wizard to generate invitation links specifying the role and optional med access.
 - Admins can grant a **med** role. Users with this role see a second toggle on the general panel which writes to `medRelaystate`.
 - The ESP32 watches `medRelaystate` as well and unlocks the relay when this value becomes `unlocked`.
-- When offline, the general panel instructs users to join the `da-box-59` AP and provides a button to copy the PIN and access link. Sub admins can upload firmware from the ESP's local page.
+ - When offline, the general panel instructs users to join the `da-box-59` AP and provides a button to copy the PIN and local link. This link already includes the PIN so it opens directly to the unlock page. Sub admins can upload firmware from the ESP's local page.
 Replace the Firebase configuration in `auth.js` with your own project details before deploying.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ This app provides a simple interface for unlocking and locking a relay using Fir
 - Over-the-air updates are available via a simple `/update` endpoint so admins can upload new firmware directly from the web UI.
 - The general panel reads `/offlinePinGeneral` for normal users and `/offlinePinSub` for sub admins to display the current PIN when the device goes offline.
  - Relay hold time saved from the admin panel is also stored in the Realtime Database at `/relayHoldTime/ms`. Both toggles write the same value whenever they unlock so hardware sees the latest hold time. The ESP writes `locked` back when the cycle ends so the UI only reverts once the board confirms.
-- The general panel shows a green "Device online" message when a heartbeat is received from the ESP and turns red when the heartbeat stops.
+- The general panel shows a pulsing green heart when the ESP heartbeat is active and turns red when it stops.
+- Admins can lock user accounts from the admin panel so locked users cannot sign in.
+- Sub admins use a wizard to generate invitation links specifying the role and optional med access.
 - Admins can grant a **med** role. Users with this role see a second toggle on the general panel which writes to `medRelaystate`.
 - The ESP32 watches `medRelaystate` as well and unlocks the relay when this value becomes `unlocked`.
 Replace the Firebase configuration in `auth.js` with your own project details before deploying.

--- a/README.md
+++ b/README.md
@@ -28,4 +28,5 @@ This app provides a simple interface for unlocking and locking a relay using Fir
 - Sub admins use a wizard to generate invitation links specifying the role and optional med access.
 - Admins can grant a **med** role. Users with this role see a second toggle on the general panel which writes to `medRelaystate`.
 - The ESP32 watches `medRelaystate` as well and unlocks the relay when this value becomes `unlocked`.
+- When offline, the general panel instructs users to join the `da-box-59` AP and provides a button to copy the PIN and access link. Sub admins can upload firmware from the ESP's local page.
 Replace the Firebase configuration in `auth.js` with your own project details before deploying.

--- a/admin.html
+++ b/admin.html
@@ -11,15 +11,18 @@
   <div class="w-full max-w-xl space-y-6">
     <header class="flex justify-between items-center">
       <h1 class="text-3xl font-semibold">Admin Panel</h1>
-      <button onclick="logout()" class="text-red-400 hover:underline">Logout</button>
+      <div class="flex items-center gap-4">
+        <div id="hbAdmin" class="text-red-400 text-2xl animate-pulse">❤️</div>
+        <button onclick="logout()" class="text-red-400 hover:underline">Logout</button>
+      </div>
     </header>
 
     <button onclick="generateToken()" class="w-full bg-green-600 p-2 rounded">Generate &amp; Copy Token</button>
 
     <div class="grid gap-4 md:grid-cols-2">
       <div>
-        <label class="block mb-1">Inactivity Timeout (ms)</label>
-        <input id="inactivityTimeout" type="number" class="w-full p-2 bg-gray-700 border border-gray-600 rounded" placeholder="3000" />
+        <label class="block mb-1">Inactivity Timeout (s)</label>
+        <input id="inactivityTimeout" type="number" class="w-full p-2 bg-gray-700 border border-gray-600 rounded" placeholder="30" />
         <button onclick="saveTimeout()" class="mt-2 w-full bg-blue-500 p-2 rounded">Save</button>
       </div>
       <div>
@@ -31,6 +34,11 @@
         <label class="block mb-1">Firmware Update (.bin)</label>
         <input id="otaFile" type="file" accept=".bin" class="w-full text-sm bg-gray-700 border border-gray-600 rounded" />
         <button onclick="uploadOTA()" class="mt-2 w-full bg-purple-600 p-2 rounded">Upload</button>
+      </div>
+      <div>
+        <label class="block mb-1">Current Offline PINs</label>
+        <div class="text-sm">General: <span id="pinGen">--</span></div>
+        <div class="text-sm">Sub: <span id="pinSub">--</span></div>
       </div>
     </div>
 
@@ -69,6 +77,13 @@
     const rtdb = getDatabase(app);
     const $ = id => document.getElementById(id);
     let espIp = "";
+    let inactivitySec = 0;
+    let inactTimer;
+    const resetInact = () => {
+      clearTimeout(inactTimer);
+      if (inactivitySec > 0) inactTimer = setTimeout(() => logout(), inactivitySec * 1000);
+    };
+    ["click","keydown","mousemove","touchstart"].forEach(e => document.addEventListener(e, resetInact));
 
     const showNotif = msg => {
       const el = $("toast");
@@ -88,7 +103,11 @@
 
     window.saveTimeout = async () => {
       const val = parseInt($("inactivityTimeout").value);
-      if (!isNaN(val)) await setDoc(doc(db, "config", "inactivity"), { timeout: val });
+      if (!isNaN(val)) {
+        await setDoc(doc(db, "config", "inactivity"), { timeout: val });
+        inactivitySec = val;
+        resetInact();
+      }
       showNotif("Saved inactivity timeout");
     };
 
@@ -136,7 +155,12 @@
       if (snap.data()?.role !== "admin") return location.href = "general.html";
 
       const conf = await getDoc(doc(db, "config", "inactivity"));
-      if (conf.exists()) $("inactivityTimeout").value = conf.data().timeout || 3000;
+      if (conf.exists()) {
+        const t = conf.data().timeout || 0;
+        $("inactivityTimeout").value = t;
+        inactivitySec = t;
+        resetInact();
+      }
 
       const holdConf = await getDoc(doc(db, "config", "relayHoldTime"));
       if (holdConf.exists()) $("relayHoldTime").value = holdConf.data().ms || 3000;
@@ -144,7 +168,15 @@
       onValue(ref(rtdb, "heartbeat"), s => {
         const v = s.val();
         espIp = v && v.ip ? v.ip : "";
+        const heart = $("hbAdmin");
+        if (heart) {
+          heart.classList.toggle("text-green-400", !!v);
+          heart.classList.toggle("text-red-400", !v);
+        }
       });
+
+      onValue(ref(rtdb, "offlinePinGeneral"), s => $("pinGen").textContent = s.val() || "--");
+      onValue(ref(rtdb, "offlinePinSub"), s => $("pinSub").textContent = s.val() || "--");
 
       const snapUsers = await getDocs(collection(db, "users"));
       snapUsers.forEach(docSnap => {
@@ -163,25 +195,33 @@
               <input type="checkbox" class="medChk" />
               <span>Med</span>
             </label>
+            <label class="flex items-center gap-1 text-sm">
+              <input type="checkbox" class="lockChk" />
+              <span>Locked</span>
+            </label>
           </div>
         `;
         const sel = row.querySelector("select");
         const medChk = row.querySelector(".medChk");
+        const lockChk = row.querySelector(".lockChk");
         sel.value = u.role;
         const label = row.querySelector("div");
         const roles = new Set(u.roles || []);
         if (roles.has("med")) medChk.checked = true;
+        if (u.locked) lockChk.checked = true;
         const updateUser = async () => {
           medChk.checked ? roles.add("med") : roles.delete("med");
           await updateDoc(doc(db, "users", docSnap.id), {
             role: sel.value,
-            roles: Array.from(roles)
+            roles: Array.from(roles),
+            locked: lockChk.checked
           });
           label.textContent = `${u.name} → ${sel.value}`;
           showNotif("User updated");
         };
         sel.onchange = updateUser;
         medChk.onchange = updateUser;
+        lockChk.onchange = updateUser;
         $("userList").appendChild(row);
       });
 

--- a/admin.html
+++ b/admin.html
@@ -12,7 +12,7 @@
     <header class="flex justify-between items-center">
       <h1 class="text-3xl font-semibold">Admin Panel</h1>
       <div class="flex items-center gap-4">
-        <div id="hbAdmin" class="text-red-400 text-2xl animate-pulse">❤️</div>
+        <div id="hbAdmin" class="text-red-400 text-2xl">❤️</div>
         <button onclick="logout()" class="text-red-400 hover:underline">Logout</button>
       </div>
     </header>

--- a/auth.js
+++ b/auth.js
@@ -54,6 +54,11 @@ window.login = async () => {
     const cred = await signInWithEmailAndPassword(auth, email, pass);
     const snap = await getDoc(doc(db, "users", cred.user.uid));
     if (!snap.exists()) return;
+    if (snap.data().locked) {
+      await signOut(auth);
+      $("msg").textContent = "Account locked";
+      return;
+    }
     const role = snap.data().role;
     if (role === "admin") location.href = "admin.html";
     else location.href = "general.html";
@@ -85,10 +90,15 @@ if (location.href.includes("register")) {
           return;
         }
         const cred = await createUserWithEmailAndPassword(auth, email, pass);
+        const data = tokSnap.data();
+        const role = data.role || "general";
+        const roles = [];
+        if (role === "general" && data.med) roles.push("med");
         await setDoc(doc(db, "users", cred.user.uid), {
           name,
-          role: "general",
-          roles: []
+          role,
+          roles,
+          locked: false
         });
         await updateDoc(doc(db, "registerTokens", token), { used: true });
         showNotif("Registration successful");
@@ -114,6 +124,18 @@ if (location.href.includes("general")) {
     const closeOffline = $("closeOffline");
     const launchOffline = $("launchOffline");
     const offlineCodeInput = $("offlineCodeInput");
+    const copyOffline = $("copyOffline");
+    const tokenModal = $("tokenModal");
+    const tokenStep1 = $("tokenStep1");
+    const tokenStep2 = $("tokenStep2");
+    const cancelToken = $("cancelToken");
+    const nextToken = $("nextToken");
+    const doneToken = $("doneToken");
+    const copyTokenLink = $("copyTokenLink");
+    const tokenLink = $("tokenLink");
+    const qrImg = $("qrImg");
+    const medFlag = $("medFlag");
+    const medWrap = $("medWrap");
     const errorText = $("errorText");
     const cancelError = $("cancelError");
     const sendError = $("sendError");
@@ -125,6 +147,13 @@ if (location.href.includes("general")) {
     let offlinePinSub = "";
     let offlinePin = "";
     let offlineShown = false;
+    let inactivitySec = 0;
+    let inactTimer;
+    const resetInact = () => {
+      clearTimeout(inactTimer);
+      if (inactivitySec > 0) inactTimer = setTimeout(() => logout(), inactivitySec * 1000);
+    };
+    ["click","keydown","mousemove","touchstart"].forEach(e => document.addEventListener(e, resetInact));
 
     onAuthStateChanged(auth, async (user) => {
       if (!user) return location.href = "index.html";
@@ -162,9 +191,13 @@ if (location.href.includes("general")) {
           if (role === "sub") offlinePin = offlinePinSub;
         });
 
+        const conf = await getDoc(doc(db, "config", "inactivity"));
+        if (conf.exists()) inactivitySec = conf.data().timeout || 0;
+        resetInact();
+
         onValue(ref(rtdb, "heartbeat"), () => {
           hbLast = Date.now();
-          hbStatus.textContent = "Device online";
+          hbStatus.textContent = "❤️";
           hbStatus.classList.remove("text-red-400");
           hbStatus.classList.add("text-green-400");
           offlineShown = false;
@@ -172,7 +205,7 @@ if (location.href.includes("general")) {
         });
         setInterval(() => {
           if (Date.now() - hbLast > 15000) {
-            hbStatus.textContent = "Device offline";
+            hbStatus.textContent = "❤️";
             hbStatus.classList.remove("text-green-400");
             hbStatus.classList.add("text-red-400");
             if (!offlineShown) {
@@ -245,33 +278,60 @@ if (location.href.includes("general")) {
 
         if (role === "sub") {
           copyBtn.classList.remove("hidden");
-          copyBtn.onclick = async () => {
+          copyBtn.onclick = () => {
+            tokenModal.classList.remove("hidden");
+            tokenStep1.classList.remove("hidden");
+            tokenStep2.classList.add("hidden");
+            medFlag.checked = false;
+            medWrap.classList.remove("hidden");
+          };
+          cancelToken.onclick = () => tokenModal.classList.add("hidden");
+          nextToken.onclick = async () => {
+            const roleSel = Array.from(document.querySelectorAll('.roleRad')).find(r=>r.checked).value;
+            if (roleSel === 'sub') medWrap.classList.add('hidden');
             const newToken = uuidv4();
-            await setDoc(doc(db, "registerTokens", newToken), {
+            await setDoc(doc(db, 'registerTokens', newToken), {
               createdAt: serverTimestamp(),
-              used: false
+              used: false,
+              role: roleSel,
+              med: medFlag.checked
             });
             const url = `${location.origin}/register.html?token=${newToken}`;
-            await navigator.clipboard.writeText(url);
-            showNotif("Token copied:\n" + url);
+            tokenLink.value = url;
+            qrImg.src = `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(url)}`;
+            tokenStep1.classList.add('hidden');
+            tokenStep2.classList.remove('hidden');
           };
+          copyTokenLink.onclick = async () => {
+            await navigator.clipboard.writeText(tokenLink.value);
+            showNotif('Link copied');
+          };
+          doneToken.onclick = () => tokenModal.classList.add('hidden');
         }
 
         offlineBtn.onclick = () => {
           if (!offlinePin) return showNotif("No PIN available yet");
-          navigator.clipboard.writeText(offlinePin);
           offlineCodeInput.value = offlinePin;
-          showNotif("PIN copied:\n" + offlinePin);
           offlineModal.classList.remove("hidden");
+          resetInact();
+        };
+
+        copyOffline.onclick = async () => {
+          if (!offlinePin) return;
+          const link = `http://192.168.4.1/unlock?pin=${encodeURIComponent(offlinePin)}`;
+          await navigator.clipboard.writeText(`${offlinePin} ${link}`);
+          showNotif("Info copied");
         };
 
         closeOffline.onclick = () => {
           offlineModal.classList.add("hidden");
           offlineShown = false;
+          resetInact();
         };
         launchOffline.onclick = () => {
           const tok = offlineCodeInput.value.trim();
           if (tok) window.open(`http://192.168.4.1/unlock?pin=${encodeURIComponent(tok)}`, "_blank");
+          resetInact();
         };
 
         errorBtn.onclick = () => {

--- a/auth.js
+++ b/auth.js
@@ -140,6 +140,7 @@ if (location.href.includes("general")) {
     const cancelError = $("cancelError");
     const sendError = $("sendError");
     const hbStatus = $("hbStatus");
+    const hbLine = $("hbLine");
     let unlocked = false;
     let medUnlocked = false;
     let holdMs = 3000;
@@ -200,14 +201,18 @@ if (location.href.includes("general")) {
           hbStatus.textContent = "❤️";
           hbStatus.classList.remove("text-red-400");
           hbStatus.classList.add("text-green-400");
+          hbLine.classList.remove("bg-red-400");
+          hbLine.classList.add("bg-green-400", "animate-pulse");
+          setTimeout(() => hbLine.classList.remove("animate-pulse"), 300);
           offlineShown = false;
-          offlineModal.classList.add("hidden");
         });
         setInterval(() => {
           if (Date.now() - hbLast > 15000) {
             hbStatus.textContent = "❤️";
             hbStatus.classList.remove("text-green-400");
             hbStatus.classList.add("text-red-400");
+            hbLine.classList.remove("bg-green-400", "animate-pulse");
+            hbLine.classList.add("bg-red-400");
             if (!offlineShown) {
               offlineShown = true;
               offlineCodeInput.value = offlinePin;
@@ -328,6 +333,13 @@ if (location.href.includes("general")) {
           offlineShown = false;
           resetInact();
         };
+        offlineModal.addEventListener("click", e => {
+          if (e.target === offlineModal) {
+            offlineModal.classList.add("hidden");
+            offlineShown = false;
+            resetInact();
+          }
+        });
         launchOffline.onclick = () => {
           const tok = offlineCodeInput.value.trim();
           if (tok) window.open(`http://192.168.4.1/unlock?pin=${encodeURIComponent(tok)}`, "_blank");

--- a/esp32_relay_watch.ino
+++ b/esp32_relay_watch.ino
@@ -42,15 +42,23 @@ WebServer server(80);
 bool otaStarted = false;
 String offlinePinGeneral = "0000";
 String offlinePinSub = "0000";
-const char* loginPage = "<!DOCTYPE html><html><head><meta name='viewport' content='width=device-width,initial-scale=1'><style>body{font-family:sans-serif;text-align:center;padding-top:20px}</style></head><body><h1>DaBox Offline</h1><form action='/unlock'><input name='pin' placeholder='PIN'><button type='submit'>Enter</button></form></body></html>";
+const char* loginPage = "<!DOCTYPE html><html><head><meta name='viewport' content='width=device-width,initial-scale=1'>"
+  "<style>body{font-family:sans-serif;background:#111;color:#fff;text-align:center;padding-top:40px}"
+  "input,button{padding:0.5rem;font-size:1rem;border-radius:4px;margin:0.25rem}"
+  "</style></head><body><h1>DaBox Offline</h1><form action='/unlock'>"
+  "<input name='pin' placeholder='PIN'><button type='submit'>Enter</button>" 
+  "</form></body></html>";
 
 String controlPage(const String& pin, bool sub) {
-  String page = "<!DOCTYPE html><html><head><meta name='viewport' content='width=device-width,initial-scale=1'><style>body{font-family:sans-serif;text-align:center;padding-top:20px}</style></head><body><h1>DaBox Controls</h1>";
-  page += "<form action='/main'><input type='hidden' name='pin' value='" + pin + "'><button type='submit'>Unlock Main</button></form>";
-  if (sub) {
-    page += "<form action='/med'><input type='hidden' name='pin' value='" + pin + "'><button type='submit'>Unlock Med</button></form>";
-  }
-  page += "<form method='POST' action='/update' enctype='multipart/form-data'><input type='file' name='firmware'><button type='submit'>Update</button></form></body></html>";
+  String page = "<!DOCTYPE html><html><head><meta name='viewport' content='width=device-width,initial-scale=1'>";
+  page += "<style>body{font-family:sans-serif;background:#111;color:#fff;text-align:center;padding-top:20px}";
+  page += "button{width:140px;height:140px;font-size:1.2rem;font-weight:bold;border:none;border-radius:12px;margin:0.5rem;background:#dc2626;color:#fff}";
+  page += ".on{background:#16a34a}";
+  page += "</style><script>function send(p,id){fetch(p+\"?pin=\"+'" + pin + "').then(_=>{var b=document.getElementById(id);b.textContent='UNLOCKED';b.classList.add('on');b.disabled=true;});}</script></head><body><h1>DaBox Controls</h1>";
+  page += "<button id='mainBtn' onclick=\"send('/main','mainBtn')\">LOCKED</button>";
+  if (sub) page += "<button id='medBtn' onclick=\"send('/med','medBtn')\">MED LOCKED</button>";
+  if (sub) page += "<form method='POST' action='/update' enctype='multipart/form-data' style='margin-top:1rem'><input type='file' name='firmware'><button type='submit'>Update</button></form>";
+  page += "</body></html>";
   return page;
 }
 

--- a/esp32_relay_watch.ino
+++ b/esp32_relay_watch.ino
@@ -45,8 +45,8 @@ String offlinePinSub = "0000";
 const char* loginPage = "<!DOCTYPE html><html><head><meta name='viewport' content='width=device-width,initial-scale=1'>"
   "<style>body{font-family:sans-serif;background:#111;color:#fff;text-align:center;padding-top:40px}"
   "input,button{padding:0.5rem;font-size:1rem;border-radius:4px;margin:0.25rem}"
-  "</style></head><body><h1>DaBox Offline</h1><form action='/unlock'>"
-  "<input name='pin' placeholder='PIN'><button type='submit'>Enter</button>" 
+  "</style></head><body><h1>DaBox Offline</h1><p>Enter your PIN to access controls.</p><form action='/unlock'>"
+  "<input name='pin' placeholder='PIN'><button type='submit'>Enter</button>"
   "</form></body></html>";
 
 String controlPage(const String& pin, bool sub) {
@@ -54,7 +54,7 @@ String controlPage(const String& pin, bool sub) {
   page += "<style>body{font-family:sans-serif;background:#111;color:#fff;text-align:center;padding-top:20px}";
   page += "button{width:140px;height:140px;font-size:1.2rem;font-weight:bold;border:none;border-radius:12px;margin:0.5rem;background:#dc2626;color:#fff}";
   page += ".on{background:#16a34a}";
-  page += "</style><script>function send(p,id){fetch(p+\"?pin=\"+'" + pin + "').then(_=>{var b=document.getElementById(id);b.textContent='UNLOCKED';b.classList.add('on');b.disabled=true;});}</script></head><body><h1>DaBox Controls</h1>";
+  page += "</style><script>function send(p,id){fetch(p+\"?pin=\"+'" + pin + "').then(_=>{var b=document.getElementById(id);b.textContent='UNLOCKED';b.classList.add('on');b.disabled=true;});}</script></head><body><h1>DaBox Controls</h1><p>Tap a button to unlock. Sub admins can upload firmware below.</p>";
   page += "<button id='mainBtn' onclick=\"send('/main','mainBtn')\">LOCKED</button>";
   if (sub) page += "<button id='medBtn' onclick=\"send('/med','medBtn')\">MED LOCKED</button>";
   if (sub) page += "<form method='POST' action='/update' enctype='multipart/form-data' style='margin-top:1rem'><input type='file' name='firmware'><button type='submit'>Update</button></form>";

--- a/general.html
+++ b/general.html
@@ -8,7 +8,7 @@
   <style>#toast{transition:opacity .3s;} .hidden{opacity:0;} body{font-family:system-ui,sans-serif;}</style>
 </head>
   <body class="bg-gradient-to-b from-gray-900 to-gray-800 text-white min-h-screen p-4 sm:p-6 flex flex-col items-center justify-center">
-  <div id="hbStatus" class="mb-4 text-red-400 text-2xl animate-pulse">❤️</div>
+  <div id="hbStatus" class="mb-4 text-red-400 text-2xl">❤️</div>
   <div class="flex flex-col sm:flex-row gap-4">
     <button id="toggleBtn" class="w-60 h-60 sm:w-80 sm:h-80 rounded-xl shadow-lg text-5xl font-bold bg-red-600">LOCKED</button>
     <button id="medToggle" class="hidden w-60 h-60 sm:w-80 sm:h-80 rounded-xl shadow-lg text-5xl font-bold bg-red-600">MED LOCKED</button>
@@ -41,6 +41,7 @@
         <li>Open <b>http://192.168.4.1</b> in your browser.</li>
         <li>Enter the PIN below to unlock.</li>
       </ol>
+      <p class="text-xs text-gray-300">The Open Link button automatically includes your PIN.</p>
       <input id="offlineCodeInput" readonly class="w-full p-2 bg-gray-700 rounded text-lg text-center" placeholder="Offline PIN" />
       <button id="copyOffline" class="bg-gray-700 px-4 py-2 rounded w-full">Copy PIN &amp; Link</button>
       <button id="launchOffline" class="bg-blue-600 px-4 py-2 rounded w-full">Open Link</button>

--- a/general.html
+++ b/general.html
@@ -8,7 +8,7 @@
   <style>#toast{transition:opacity .3s;} .hidden{opacity:0;} body{font-family:system-ui,sans-serif;}</style>
 </head>
 <body class="bg-gray-900 text-white min-h-screen p-4 sm:p-6 flex flex-col items-center justify-center">
-  <div id="hbStatus" class="mb-4 text-red-400">Device offline</div>
+  <div id="hbStatus" class="mb-4 text-red-400 text-2xl animate-pulse">❤️</div>
   <div class="flex flex-col sm:flex-row gap-4">
     <button id="toggleBtn" class="w-60 h-60 sm:w-80 sm:h-80 rounded-xl shadow-lg text-5xl font-bold bg-red-600">LOCKED</button>
     <button id="medToggle" class="hidden w-60 h-60 sm:w-80 sm:h-80 rounded-xl shadow-lg text-5xl font-bold bg-red-600">MED LOCKED</button>
@@ -35,10 +35,31 @@
 
   <div id="offlineModal" class="fixed inset-0 bg-black/50 flex items-center justify-center hidden">
     <div class="bg-gray-800 p-4 rounded space-y-4 w-full max-w-md text-center">
-      <p>Device appears offline. Connect to <b>da-box-59</b> and use the PIN below.</p>
-      <input id="offlineCodeInput" class="w-full p-2 bg-gray-700 rounded" placeholder="Offline PIN" />
-      <button id="launchOffline" class="bg-blue-600 px-4 py-2 rounded w-full">Open AP Link</button>
+      <p class="text-sm">Connect to <b>da-box-59</b> and open <b>http://192.168.4.1</b>.</p>
+      <input id="offlineCodeInput" readonly class="w-full p-2 bg-gray-700 rounded" placeholder="Offline PIN" />
+      <button id="copyOffline" class="bg-gray-700 px-4 py-2 rounded w-full">Copy PIN &amp; Link</button>
+      <button id="launchOffline" class="bg-blue-600 px-4 py-2 rounded w-full">Open Link</button>
       <button id="closeOffline" class="bg-gray-600 px-2 py-1 rounded w-full">Close</button>
+    </div>
+  </div>
+
+  <div id="tokenModal" class="fixed inset-0 bg-black/50 flex items-center justify-center hidden">
+    <div id="tokenStep1" class="bg-gray-800 p-4 rounded space-y-4 w-full max-w-md">
+      <h3 class="text-lg font-semibold text-center">Invite User</h3>
+      <label class="flex items-center gap-2"><input type="radio" name="uRole" value="general" class="roleRad" checked>General</label>
+      <label class="flex items-center gap-2"><input type="radio" name="uRole" value="sub" class="roleRad">Sub Admin</label>
+      <label id="medWrap" class="flex items-center gap-2"><input type="checkbox" id="medFlag">Med Button</label>
+      <div class="flex justify-end gap-2">
+        <button id="cancelToken" class="bg-gray-600 px-4 py-2 rounded">Cancel</button>
+        <button id="nextToken" class="bg-blue-600 px-4 py-2 rounded">Next</button>
+      </div>
+    </div>
+    <div id="tokenStep2" class="bg-gray-800 p-4 rounded space-y-4 w-full max-w-md hidden text-center">
+      <p>Share this link with the user.</p>
+      <img id="qrImg" class="mx-auto" />
+      <input id="tokenLink" readonly class="w-full p-2 bg-gray-700 rounded text-sm" />
+      <button id="copyTokenLink" class="bg-gray-700 px-4 py-2 rounded w-full">Copy Link</button>
+      <button id="doneToken" class="bg-blue-600 px-4 py-2 rounded w-full">Done</button>
     </div>
   </div>
 

--- a/general.html
+++ b/general.html
@@ -7,7 +7,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <style>#toast{transition:opacity .3s;} .hidden{opacity:0;} body{font-family:system-ui,sans-serif;}</style>
 </head>
-<body class="bg-gray-900 text-white min-h-screen p-4 sm:p-6 flex flex-col items-center justify-center">
+  <body class="bg-gradient-to-b from-gray-900 to-gray-800 text-white min-h-screen p-4 sm:p-6 flex flex-col items-center justify-center">
   <div id="hbStatus" class="mb-4 text-red-400 text-2xl animate-pulse">❤️</div>
   <div class="flex flex-col sm:flex-row gap-4">
     <button id="toggleBtn" class="w-60 h-60 sm:w-80 sm:h-80 rounded-xl shadow-lg text-5xl font-bold bg-red-600">LOCKED</button>
@@ -35,8 +35,13 @@
 
   <div id="offlineModal" class="fixed inset-0 bg-black/50 flex items-center justify-center hidden">
     <div class="bg-gray-800 p-4 rounded space-y-4 w-full max-w-md text-center">
-      <p class="text-sm">Connect to <b>da-box-59</b> and open <b>http://192.168.4.1</b>.</p>
-      <input id="offlineCodeInput" readonly class="w-full p-2 bg-gray-700 rounded" placeholder="Offline PIN" />
+      <p class="text-sm">Follow these steps when the device goes offline:</p>
+      <ol class="text-sm list-decimal list-inside space-y-1 text-left">
+        <li>Join the <b>da-box-59</b> WiFi network.</li>
+        <li>Open <b>http://192.168.4.1</b> in your browser.</li>
+        <li>Enter the PIN below to unlock.</li>
+      </ol>
+      <input id="offlineCodeInput" readonly class="w-full p-2 bg-gray-700 rounded text-lg text-center" placeholder="Offline PIN" />
       <button id="copyOffline" class="bg-gray-700 px-4 py-2 rounded w-full">Copy PIN &amp; Link</button>
       <button id="launchOffline" class="bg-blue-600 px-4 py-2 rounded w-full">Open Link</button>
       <button id="closeOffline" class="bg-gray-600 px-2 py-1 rounded w-full">Close</button>

--- a/general.html
+++ b/general.html
@@ -8,8 +8,11 @@
   <style>#toast{transition:opacity .3s;} .hidden{opacity:0;} body{font-family:system-ui,sans-serif;}</style>
 </head>
   <body class="bg-gradient-to-b from-gray-900 to-gray-800 text-white min-h-screen p-4 sm:p-6 flex flex-col items-center justify-center">
-  <div id="hbStatus" class="mb-4 text-red-400 text-2xl">❤️</div>
-  <div class="flex flex-col sm:flex-row gap-4">
+  <div class="relative flex flex-col sm:flex-row gap-4 mb-4 items-center justify-center">
+    <div id="hbWrap" class="absolute inset-0 -z-10 flex flex-col items-center justify-center pointer-events-none">
+      <div id="hbStatus" class="text-red-400 text-4xl opacity-50">❤️</div>
+      <div id="hbLine" class="w-12 h-px bg-red-400 mt-1 opacity-50"></div>
+    </div>
     <button id="toggleBtn" class="w-60 h-60 sm:w-80 sm:h-80 rounded-xl shadow-lg text-5xl font-bold bg-red-600">LOCKED</button>
     <button id="medToggle" class="hidden w-60 h-60 sm:w-80 sm:h-80 rounded-xl shadow-lg text-5xl font-bold bg-red-600">MED LOCKED</button>
   </div>


### PR DESCRIPTION
## Summary
- style offline panel with a pulsing heart
- add wizard to invite users with role/med flag
- show offline instructions and copy link
- display heartbeat and offline pins on admin page
- allow admins to lock accounts and set inactivity in seconds
- enhance ESP offline pages with toggle UI

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68552d9224908329bae315e6979ed028