### PR TITLE
Fix delete modal on general page

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -349,9 +349,9 @@ if (location.href.includes("general")) {
           resetInact();
         };
 
-        deleteBtn.onclick = () => {
+        deleteBtn.addEventListener('click', () => {
           deleteModal.classList.remove('hidden');
-        };
+        });
 
         copyOffline.onclick = async () => {
           if (!offlinePin) return;

--- a/general.html
+++ b/general.html
@@ -18,7 +18,7 @@
   </div>
   <div class="mt-6 flex flex-wrap gap-4 justify-center">
     <button onclick="logout()" class="bg-gray-700 px-4 py-2 rounded">Logout</button>
-    <button id="deleteBtn" onclick="deleteAccount()" class="bg-gray-700 px-4 py-2 rounded">Delete</button>
+    <button id="deleteBtn" class="bg-gray-700 px-4 py-2 rounded">Delete</button>
     <button id="copyBtn" class="hidden bg-gray-700 px-4 py-2 rounded">Invite Users</button>
     <button id="offlineBtn" class="bg-gray-700 px-4 py-2 rounded">Offline PIN</button>
     <button id="errorBtn" class="bg-gray-700 px-4 py-2 rounded">Report Issue</button>


### PR DESCRIPTION
## Summary
- remove inline delete onclick from general page
- attach click listener in JS for delete modal

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68562a4a331083298bd707455ce7061d